### PR TITLE
Update GP_Player.cs

### DIFF
--- a/Demo/Assets/Plugins/GamePush/Runtime/Modules/GP_Player.cs
+++ b/Demo/Assets/Plugins/GamePush/Runtime/Modules/GP_Player.cs
@@ -202,11 +202,11 @@ namespace GamePush
         
         private async void Start()
         {
-            await GP_Init.Ready;
-            FetchFields(fields =>
-            {
-                PlayerFields = fields;
-            });
+        //    await GP_Init.Ready;
+        //    FetchFields(fields =>
+        //    {
+        //        PlayerFields = fields;
+        //    });
         }
 
         #region Getters


### PR DESCRIPTION
Убирает Fetch переменных игрока на старте, это создает один тарифицируемый запрос, который не нужен, ведь после готовности сдк и игрока - переменные сразу доступны к работе с ними, например GP_Player.GetInt() и аналогами.