### PR TITLE
Update GP_Player.cs

### DIFF
--- a/Demo/Assets/Plugins/GamePush/Runtime/Modules/GP_Player.cs
+++ b/Demo/Assets/Plugins/GamePush/Runtime/Modules/GP_Player.cs
@@ -200,14 +200,14 @@ namespace GamePush
 #endif
         #endregion
         
-        private async void Start()
-        {
-            await GP_Init.Ready;
-            FetchFields(fields =>
-            {
-                PlayerFields = fields;
-            });
-        }
+        //private async void Start()
+        //{
+        //    await GP_Init.Ready;
+        //    FetchFields(fields =>
+        //    {
+        //        PlayerFields = fields;
+        //    });
+        //}
 
         #region Getters
 


### PR DESCRIPTION
Убирает Fetch переменных игрока на старте, это создает тарифицируемый запрос, который не нужен, ведь после готовности сдк и игрока - переменные сразу доступны к работе с ними, например GP_Player.GetInt() и аналоги.